### PR TITLE
Fix the geocoderPosition documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The example below, is the search component with full options: <br>
         :center="[14, 17]" 
         :zoom="2" 
         :navigationControls="true"
-        :geocoderPosition="top-left"
+        geocoderPosition="top-left"
         :rtl="true"
         :cooperativeGestures="true"
     />


### PR DESCRIPTION
This PR will fix the typo of the geocoderPosition when using the search component mentioned here #13 
 