### PR TITLE
Add map position as param

### DIFF
--- a/resources/views/components/mapbox-search.blade.php
+++ b/resources/views/components/mapbox-search.blade.php
@@ -1,6 +1,6 @@
 <style>
     #{{ $id }} {
-        position: absolute;
+        position: {{ $position }};
         top: 0;
         bottom: 0;
         {{ $attributes['style'] && Str::contains($attributes['style'], 'width') ? $attributes['style'] : $attributes['style'] . 'width: 100%;' }}

--- a/resources/views/components/mapbox.blade.php
+++ b/resources/views/components/mapbox.blade.php
@@ -1,6 +1,6 @@
 <style>
     #{{ $id }} {
-        position: absolute;
+        position: {{ $position }};
         top: 0;
         bottom: 0;
         {{ $attributes['style'] && Str::contains($attributes['style'], 'width') ? $attributes['style'] : $attributes['style'] . 'width: 100%;' }}

--- a/src/Components/Mapbox.php
+++ b/src/Components/Mapbox.php
@@ -9,7 +9,7 @@ class Mapbox extends Component
 {
     public function __construct(
         public String $id,
-        public array $center = [0,0],
+        public array $center = [0, 0],
         public int $zoom = 8,
         public bool $navigationControls = false,
         public bool $cooperativeGestures = false,
@@ -18,6 +18,7 @@ class Mapbox extends Component
         public bool $interactive = true,
         public array $markers = [],
         public bool $draggable = false,
+        public string $position = 'absolute',
     ) {
     }
 

--- a/src/Components/MapboxSearch.php
+++ b/src/Components/MapboxSearch.php
@@ -9,14 +9,15 @@ class MapboxSearch extends Component
 {
     public function __construct(
         public String $id,
-        public String $placeholder="Search",
-        public array $center = [0,0],
+        public String $placeholder = "Search",
+        public array $center = [0, 0],
         public int $zoom = 8,
         public bool $navigationControls = false,
         public string $geocoderPosition = 'top-left',
         public bool $cooperativeGestures = false,
         public string $mapStyle = 'mapbox/streets-v11',
         public bool $rtl = false,
+        public string $position = 'absolute',
     ) {
     }
 

--- a/tests/MapboxRenderingTest.php
+++ b/tests/MapboxRenderingTest.php
@@ -114,3 +114,8 @@ it('render a custom marker icon', function () {
     ]]);
     $view->assertSee('https://placekitten.com/g/50/50');
 });
+
+it('can accept the position as param', function () {
+    $view = $this->component(Mapbox::class, ['id' => 'map', 'position' => 'relative']);
+    $view->assertSee('relative');
+});


### PR DESCRIPTION
This PR will add the ability to accept the map css `position` attribute as a param. 
The default will be `position: absolute` as the Mapbox documentation suggests.
This PR will fix   #15 .